### PR TITLE
scene: add support for custom shaders in mirrors, images and text

### DIFF
--- a/include/config/config.h
+++ b/include/config/config.h
@@ -57,6 +57,11 @@ struct config {
         double ninb_opacity;
     } theme;
 
+    struct {
+        struct config_shader *data;
+        size_t count;
+    } shaders;
+
     struct config_vm *vm;
 };
 
@@ -83,6 +88,12 @@ enum config_remap_type {
 struct config_remap {
     enum config_remap_type src_type, dst_type;
     uint32_t src_data, dst_data;
+};
+
+struct config_shader {
+    char* name;
+    char* fragment;
+    char* vertex;
 };
 
 struct config *config_create();

--- a/include/config/config.h
+++ b/include/config/config.h
@@ -91,9 +91,9 @@ struct config_remap {
 };
 
 struct config_shader {
-    char* name;
-    char* fragment;
-    char* vertex;
+    char *name;
+    char *fragment;
+    char *vertex;
 };
 
 struct config *config_create();

--- a/include/scene.h
+++ b/include/scene.h
@@ -2,6 +2,7 @@
 #define WAYWALL_SCENE_H
 
 #include "util/box.h"
+#include "config/config.h"
 #include <wayland-server-core.h>
 #include <wayland-util.h>
 
@@ -12,15 +13,11 @@ struct scene {
     uint32_t image_max_size;
 
     struct {
-        struct server_gl_shader *texcopy;
-        int texcopy_u_src_size, texcopy_u_dst_size;
-        int texcopy_a_src_pos, texcopy_a_dst_pos, texcopy_a_src_rgba, texcopy_a_dst_rgba;
+        struct scene_shader *data;
+        size_t count;
     } shaders;
 
     struct {
-        unsigned int mirrors;
-        size_t mirrors_vtxcount;
-
         unsigned int debug;
         size_t debug_vtxcount;
 
@@ -34,14 +31,29 @@ struct scene {
     struct wl_listener on_gl_frame;
 };
 
+static const int SHADER_SRC_POS_ATTRIB_LOC = 0;
+static const int SHADER_DST_POS_ATTRIB_LOC = 1;
+static const int SHADER_SRC_RGBA_ATTRIB_LOC = 2;
+static const int SHADER_DST_RGBA_ATTRIB_LOC = 3;
+struct scene_shader {
+    struct server_gl_shader *shader;
+    int shader_u_src_size, shader_u_dst_size;
+
+    char *name;
+};
+
 struct scene_image_options {
     struct box dst;
+
+    char *shader_name;
 };
 
 struct scene_mirror_options {
     struct box src, dst;
     float src_rgba[4];
     float dst_rgba[4];
+
+    char *shader_name;
 };
 
 struct scene_text_options {
@@ -50,9 +62,11 @@ struct scene_text_options {
 
     float rgba[4];
     int32_t size_multiplier;
+
+    char *shader_name;
 };
 
-struct scene *scene_create(struct server_gl *gl, struct server_ui *ui);
+struct scene *scene_create(struct config *cfg, struct server_gl *gl, struct server_ui *ui);
 void scene_destroy(struct scene *scene);
 
 struct scene_image *scene_add_image(struct scene *scene, const struct scene_image_options *options,

--- a/include/scene.h
+++ b/include/scene.h
@@ -1,8 +1,8 @@
 #ifndef WAYWALL_SCENE_H
 #define WAYWALL_SCENE_H
 
-#include "util/box.h"
 #include "config/config.h"
+#include "util/box.h"
 #include <wayland-server-core.h>
 #include <wayland-util.h>
 

--- a/include/scene.h
+++ b/include/scene.h
@@ -63,7 +63,7 @@ struct scene_text_options {
     float rgba[4];
     int32_t size_multiplier;
 
-    char *shader_name;
+    const char *shader_name;
 };
 
 struct scene *scene_create(struct config *cfg, struct server_gl *gl, struct server_ui *ui);

--- a/waywall/config/api.c
+++ b/waywall/config/api.c
@@ -830,9 +830,9 @@ l_text(lua_State *L) {
         size = luaL_checkinteger(L, ARG_SIZE);
     }
 
-    char* shader = NULL;
+    char* shader_name = NULL;
     if (lua_gettop(L) >= ARG_SHADER) {
-        shader = strdup(luaL_checkstring(L, ARG_SHADER));
+        shader_name = luaL_checkstring(L, ARG_SHADER);
     }
     lua_settop(L, ARG_SHADER);
 
@@ -841,7 +841,7 @@ l_text(lua_State *L) {
         .y = y,
         .rgba = {rgba[0], rgba[1], rgba[2], rgba[3]},
         .size_multiplier = size,
-        .shader_name = shader,
+        .shader_name = shader_name,
     };
 
     // Body

--- a/waywall/config/api.c
+++ b/waywall/config/api.c
@@ -414,7 +414,14 @@ l_image(lua_State *L) {
     lua_settop(L, ARG_OPTIONS);
 
     struct scene_image_options options = {0};
-    unmarshal_box(L, &options.dst);
+    unmarshal_box_key(L, "dst", &options.dst);
+
+    lua_pushstring(L, "shader");
+    lua_rawget(L, ARG_OPTIONS);
+    if (lua_type(L, -1) == LUA_TSTRING) {
+        options.shader_name = strdup(lua_tostring(L, -1));
+    }
+    lua_pop(L, 1);
 
     int fd = open(path, O_RDONLY);
     if (fd == -1) {
@@ -441,6 +448,7 @@ l_image(lua_State *L) {
     lua_setmetatable(L, -2);
 
     *image = scene_add_image(wrap->scene, &options, buf, stat.st_size);
+    free(options.shader_name);
     if (!*image) {
         ww_assert(munmap(buf, stat.st_size) == 0);
         close(fd);
@@ -473,6 +481,13 @@ l_mirror(lua_State *L) {
     unmarshal_box_key(L, "src", &options.src);
     unmarshal_box_key(L, "dst", &options.dst);
 
+    lua_pushstring(L, "shader");
+    lua_rawget(L, ARG_OPTIONS);
+    if (lua_type(L, -1) == LUA_TSTRING) {
+        options.shader_name = strdup(lua_tostring(L, -1));
+    }
+    lua_pop(L, 1);
+
     lua_pushstring(L, "color_key"); // stack: 2
     lua_rawget(L, ARG_OPTIONS);     // stack: 2
 
@@ -490,6 +505,7 @@ l_mirror(lua_State *L) {
     lua_setmetatable(L, -2);
 
     *mirror = scene_add_mirror(wrap->scene, &options);
+    free(options.shader_name);
     if (!*mirror) {
         return luaL_error(L, "failed to create mirror");
     }
@@ -781,6 +797,7 @@ l_text(lua_State *L) {
     static const int ARG_Y = 3;
     static const int ARG_COLOR = 4;
     static const int ARG_SIZE = 5;
+    static const int ARG_SHADER = 6;
 
     // Prologue
     struct config_vm *vm = config_vm_from(L);
@@ -812,13 +829,19 @@ l_text(lua_State *L) {
     if (lua_gettop(L) >= ARG_SIZE) {
         size = luaL_checkinteger(L, ARG_SIZE);
     }
-    lua_settop(L, ARG_SIZE);
+
+    char* shader = NULL;
+    if (lua_gettop(L) >= ARG_SHADER) {
+        shader = strdup(luaL_checkstring(L, ARG_SHADER));
+    }
+    lua_settop(L, ARG_SHADER);
 
     struct scene_text_options options = {
         .x = x,
         .y = y,
         .rgba = {rgba[0], rgba[1], rgba[2], rgba[3]},
         .size_multiplier = size,
+        .shader_name = shader,
     };
 
     // Body

--- a/waywall/config/api.c
+++ b/waywall/config/api.c
@@ -830,7 +830,7 @@ l_text(lua_State *L) {
         size = luaL_checkinteger(L, ARG_SIZE);
     }
 
-    char* shader_name = NULL;
+    char *shader_name = NULL;
     if (lua_gettop(L) >= ARG_SHADER) {
         shader_name = luaL_checkstring(L, ARG_SHADER);
     }

--- a/waywall/config/api.c
+++ b/waywall/config/api.c
@@ -830,7 +830,7 @@ l_text(lua_State *L) {
         size = luaL_checkinteger(L, ARG_SIZE);
     }
 
-    char *shader_name = NULL;
+    const char *shader_name = NULL;
     if (lua_gettop(L) >= ARG_SHADER) {
         shader_name = luaL_checkstring(L, ARG_SHADER);
     }

--- a/waywall/config/config.c
+++ b/waywall/config/config.c
@@ -667,14 +667,13 @@ process_config_shaders(struct config *cfg) {
     // 2:   config
     const int IDX_SHADERS = 2;
     const int IDX_SHADER_KEY = 3;
-    // const int IDX_SHADER_VAL = 4;
 
     ww_assert(lua_gettop(cfg->vm->L) == IDX_SHADERS);
 
     lua_pushnil(cfg->vm->L); // stack: 3 (IDX_SHADER_KEY)
     while (lua_next(cfg->vm->L, IDX_SHADERS)) {
         // stack state:
-        // 4 (IDX_SHADER_VAL) : config.shaders[key] (should be a string)
+        // 4 (IDX_SHADER_VAL) : config.shaders[key] (should be a table)
         // 3 (IDX_SHADER_KEY) : key (should be a string)
         // 2 (IDX_SHADERS)    : config.shaders
         // 1                  : config

--- a/waywall/config/config.c
+++ b/waywall/config/config.c
@@ -51,6 +51,7 @@ static const struct config defaults = {
             .ninb_anchor = ANCHOR_NONE,
             .ninb_opacity = 1.0,
         },
+    .shaders = {0}
 };
 
 static const struct {
@@ -354,6 +355,16 @@ add_remap(struct config *cfg, struct config_remap remap) {
 }
 
 static void
+add_shader(struct config *cfg, struct config_shader shader) {
+    void *data = realloc(cfg->shaders.data,
+                         sizeof(*cfg->shaders.data) * (cfg->shaders.count + 1));
+    check_alloc(data);
+
+    cfg->shaders.data = data;
+    cfg->shaders.data[cfg->shaders.count++] = shader;
+}
+
+static void
 add_action(struct config *cfg, struct config_action *action) {
     void *data = realloc(cfg->input.actions.data,
                          sizeof(*cfg->input.actions.data) * (cfg->input.actions.count + 1));
@@ -650,6 +661,58 @@ process_config_theme(struct config *cfg) {
 }
 
 static int
+process_config_shaders(struct config *cfg) {
+    // stack state:
+    // 1:   config.shaders
+    // 2:   config
+    const int IDX_SHADERS = 2;
+    const int IDX_SHADER_KEY = 3;
+    // const int IDX_SHADER_VAL = 4;
+
+    ww_assert(lua_gettop(cfg->vm->L) == IDX_SHADERS);
+
+    lua_pushnil(cfg->vm->L); // stack: 3 (IDX_SHADER_KEY)
+    while (lua_next(cfg->vm->L, IDX_SHADERS)) {
+        // stack state:
+        // 4 (IDX_SHADER_VAL) : config.shaders[key] (should be a string)
+        // 3 (IDX_SHADER_KEY) : key (should be a string)
+        // 2 (IDX_SHADERS)    : config.shaders
+        // 1                  : config
+
+        if (!lua_isstring(cfg->vm->L, IDX_SHADER_KEY)) {
+            ww_log(LOG_ERROR, "non-string key '%s' found in shaders table",
+                   lua_tostring(cfg->vm->L, IDX_SHADER_KEY));
+            return 1;
+        }
+
+        char *key = strdup(lua_tostring(cfg->vm->L, IDX_SHADER_KEY));
+        char *fragment = NULL, *vertex = NULL;
+        if (get_string(cfg, "fragment", &fragment, "shaders[].fragment", false)) {
+            return 1;
+        }
+        if (get_string(cfg, "vertex", &vertex, "shaders[].vertex", false)) {
+            return 1;
+        }
+
+        struct config_shader shader = {
+            .name = key,
+            .fragment = fragment,
+            .vertex = vertex,
+        };
+        add_shader(cfg, shader);
+
+        // Pop the value from the top of the stack. The previous key will be left at the top of the
+        // stack for the next call to `lua_next`.
+        lua_pop(cfg->vm->L, 1); // stack: 3 (IDX_SHADER_KEY)
+        ww_assert(lua_gettop(cfg->vm->L) == IDX_SHADER_KEY);
+    }
+
+    ww_assert(lua_gettop(cfg->vm->L) == IDX_SHADERS);
+
+    return 0;
+}
+
+static int
 process_config(struct config *cfg) {
     // stack state:
     // 1:   config
@@ -668,6 +731,10 @@ process_config(struct config *cfg) {
     }
 
     if (get_table(cfg, "theme", process_config_theme, "theme", false) != 0) {
+        return 1;
+    }
+
+    if (get_table(cfg, "shaders", process_config_shaders, "shaders", false) != 0) {
         return 1;
     }
 
@@ -762,6 +829,13 @@ config_destroy(struct config *cfg) {
     free(cfg->input.keymap.options);
     free(cfg->theme.cursor_theme);
     free(cfg->theme.cursor_icon);
+
+    for (size_t i = 0; i < cfg->shaders.count; i++) {
+        free(cfg->shaders.data[i].name);
+        free(cfg->shaders.data[i].fragment);
+        free(cfg->shaders.data[i].vertex);
+    }
+    free(cfg->shaders.data);
 
     if (cfg->vm) {
         config_vm_destroy(cfg->vm);

--- a/waywall/config/config.c
+++ b/waywall/config/config.c
@@ -835,7 +835,9 @@ config_destroy(struct config *cfg) {
         free(cfg->shaders.data[i].fragment);
         free(cfg->shaders.data[i].vertex);
     }
-    free(cfg->shaders.data);
+    if (cfg->shaders.data) {
+        free(cfg->shaders.data);
+    }
 
     if (cfg->vm) {
         config_vm_destroy(cfg->vm);

--- a/waywall/config/config.c
+++ b/waywall/config/config.c
@@ -51,7 +51,7 @@ static const struct config defaults = {
             .ninb_anchor = ANCHOR_NONE,
             .ninb_opacity = 1.0,
         },
-    .shaders = {0}
+    .shaders = {0},
 };
 
 static const struct {
@@ -356,8 +356,7 @@ add_remap(struct config *cfg, struct config_remap remap) {
 
 static void
 add_shader(struct config *cfg, struct config_shader shader) {
-    void *data = realloc(cfg->shaders.data,
-                         sizeof(*cfg->shaders.data) * (cfg->shaders.count + 1));
+    void *data = realloc(cfg->shaders.data, sizeof(*cfg->shaders.data) * (cfg->shaders.count + 1));
     check_alloc(data);
 
     cfg->shaders.data = data;

--- a/waywall/scene.c
+++ b/waywall/scene.c
@@ -455,7 +455,8 @@ text_release(struct scene_text *text) {
     text->parent = NULL;
 }
 
-int shader_find_index(struct scene* scene, char* key) {
+static int
+shader_find_index(struct scene* scene, char* key) {
     if (key == NULL) {
         return 0;
     }
@@ -468,7 +469,8 @@ int shader_find_index(struct scene* scene, char* key) {
     return 0;
 }
 
-bool shader_create(struct server_gl *gl, struct scene_shader *data, char* name, const char* vertex, const char* fragment) {
+static bool
+shader_create(struct server_gl *gl, struct scene_shader *data, char* name, const char* vertex, const char* fragment) {
     data->name = name;
     data->shader =
         server_gl_compile(

--- a/waywall/scene.c
+++ b/waywall/scene.c
@@ -464,7 +464,7 @@ text_release(struct scene_text *text) {
 }
 
 static int
-shader_find_index(struct scene *scene, char *key) {
+shader_find_index(struct scene *scene, const char *key) {
     if (key == NULL) {
         return 0;
     }

--- a/waywall/scene.c
+++ b/waywall/scene.c
@@ -68,7 +68,8 @@ struct scene_text {
 
 static void build_image(struct scene_image *out, struct scene *scene,
                         const struct scene_image_options *options, int32_t width, int32_t height);
-static void build_mirror(struct scene_mirror *mirror, const struct scene_mirror_options *options, struct scene *scene);
+static void build_mirror(struct scene_mirror *mirror, const struct scene_mirror_options *options,
+                         struct scene *scene);
 static void build_rect(struct vtx_shader out[static 6], const struct box *src,
                        const struct box *dst, const float src_rgba[static 4],
                        const float dst_rgba[static 4]);
@@ -78,7 +79,8 @@ static size_t build_text(GLuint vbo, struct scene *scene, const char *data,
 static void draw_debug_text(struct scene *scene);
 static void draw_frame(struct scene *scene);
 static void draw_image(struct scene *scene, struct scene_image *image);
-static void draw_mirror(struct scene *scene, struct scene_mirror *mirror, unsigned int capture_texture, int32_t width, int32_t height);
+static void draw_mirror(struct scene *scene, struct scene_mirror *mirror,
+                        unsigned int capture_texture, int32_t width, int32_t height);
 static void draw_text(struct scene *scene, struct scene_text *text);
 
 static void draw_vertex_list(struct scene_shader *shader, size_t num_vertices);
@@ -111,11 +113,11 @@ build_image(struct scene_image *out, struct scene *scene, const struct scene_ima
 }
 
 static void
-build_mirror(struct scene_mirror *mirror, const struct scene_mirror_options *options, struct scene *scene) {
+build_mirror(struct scene_mirror *mirror, const struct scene_mirror_options *options,
+             struct scene *scene) {
     struct vtx_shader vertices[6] = {0};
 
-    build_rect(vertices, &options->src, &options->dst, options->src_rgba,
-                   mirror->dst_rgba);
+    build_rect(vertices, &options->src, &options->dst, options->src_rgba, mirror->dst_rgba);
 
     server_gl_with(scene->gl, false) {
         glGenBuffers(1, &mirror->vbo);
@@ -217,13 +219,13 @@ draw_debug_text(struct scene *scene) {
     const char *str = util_debug_str();
     scene->buffers.debug_vtxcount = build_text(
         scene->buffers.debug, scene, str,
-        &(struct scene_text_options){.x = 8, .y = 8, .rgba = {1, 1, 1, 1}, .size_multiplier = 1, .shader_name = NULL});
+        &(struct scene_text_options){
+            .x = 8, .y = 8, .rgba = {1, 1, 1, 1}, .size_multiplier = 1, .shader_name = NULL});
 
     gl_using_buffer(GL_ARRAY_BUFFER, scene->buffers.debug) {
         draw_vertex_list(&scene->shaders.data[0], scene->buffers.debug_vtxcount);
     }
 }
-
 
 static void
 draw_frame(struct scene *scene) {
@@ -272,8 +274,10 @@ static void
 draw_image(struct scene *scene, struct scene_image *image) {
     // The OpenGL context must be current.
     server_gl_shader_use(scene->shaders.data[image->shader_index].shader);
-    glUniform2f(scene->shaders.data[image->shader_index].shader_u_dst_size, scene->ui->width, scene->ui->height);
-    glUniform2f(scene->shaders.data[image->shader_index].shader_u_src_size, image->width, image->height);
+    glUniform2f(scene->shaders.data[image->shader_index].shader_u_dst_size, scene->ui->width,
+                scene->ui->height);
+    glUniform2f(scene->shaders.data[image->shader_index].shader_u_src_size, image->width,
+                image->height);
 
     gl_using_buffer(GL_ARRAY_BUFFER, image->vbo) {
         gl_using_texture(GL_TEXTURE_2D, image->tex) {
@@ -284,10 +288,12 @@ draw_image(struct scene *scene, struct scene_image *image) {
 }
 
 static void
-draw_mirror(struct scene *scene, struct scene_mirror *mirror, unsigned int capture_texture, int32_t width, int32_t height) {
+draw_mirror(struct scene *scene, struct scene_mirror *mirror, unsigned int capture_texture,
+            int32_t width, int32_t height) {
     // The OpenGL context must be current.
     server_gl_shader_use(scene->shaders.data[mirror->shader_index].shader);
-    glUniform2f(scene->shaders.data[mirror->shader_index].shader_u_dst_size, scene->ui->width, scene->ui->height);
+    glUniform2f(scene->shaders.data[mirror->shader_index].shader_u_dst_size, scene->ui->width,
+                scene->ui->height);
     glUniform2f(scene->shaders.data[mirror->shader_index].shader_u_src_size, width, height);
 
     gl_using_buffer(GL_ARRAY_BUFFER, mirror->vbo) {
@@ -302,8 +308,10 @@ static void
 draw_text(struct scene *scene, struct scene_text *text) {
     // The OpenGL context must be current.
     server_gl_shader_use(scene->shaders.data[text->shader_index].shader);
-    glUniform2f(scene->shaders.data[text->shader_index].shader_u_dst_size, scene->ui->width, scene->ui->height);
-    glUniform2f(scene->shaders.data[text->shader_index].shader_u_src_size, ATLAS_WIDTH, ATLAS_HEIGHT);
+    glUniform2f(scene->shaders.data[text->shader_index].shader_u_dst_size, scene->ui->width,
+                scene->ui->height);
+    glUniform2f(scene->shaders.data[text->shader_index].shader_u_src_size, ATLAS_WIDTH,
+                ATLAS_HEIGHT);
 
     gl_using_buffer(GL_ARRAY_BUFFER, text->vbo) {
         draw_vertex_list(&scene->shaders.data[text->shader_index], text->vtxcount);
@@ -456,7 +464,7 @@ text_release(struct scene_text *text) {
 }
 
 static int
-shader_find_index(struct scene* scene, char* key) {
+shader_find_index(struct scene *scene, char *key) {
     if (key == NULL) {
         return 0;
     }
@@ -470,22 +478,17 @@ shader_find_index(struct scene* scene, char* key) {
 }
 
 static bool
-shader_create(struct server_gl *gl, struct scene_shader *data, char* name, const char* vertex, const char* fragment) {
+shader_create(struct server_gl *gl, struct scene_shader *data, char *name, const char *vertex,
+              const char *fragment) {
     data->name = name;
-    data->shader =
-        server_gl_compile(
-            gl,
-            vertex ? vertex : WAYWALL_GLSL_TEXCOPY_VERT_H,
-            fragment ? fragment : WAYWALL_GLSL_TEXCOPY_FRAG_H
-        );
+    data->shader = server_gl_compile(gl, vertex ? vertex : WAYWALL_GLSL_TEXCOPY_VERT_H,
+                                     fragment ? fragment : WAYWALL_GLSL_TEXCOPY_FRAG_H);
     if (!data->shader) {
         return false;
     }
 
-    data->shader_u_src_size =
-        glGetUniformLocation(data->shader->program, "u_src_size");
-    data->shader_u_dst_size =
-        glGetUniformLocation(data->shader->program, "u_dst_size");
+    data->shader_u_src_size = glGetUniformLocation(data->shader->program, "u_src_size");
+    data->shader_u_dst_size = glGetUniformLocation(data->shader->program, "u_dst_size");
 
     return true;
 }
@@ -514,7 +517,9 @@ scene_create(struct config *cfg, struct server_gl *gl, struct server_ui *ui) {
             goto fail_compile_texture_copy;
         }
         for (size_t i = 0; i < cfg->shaders.count; i++) {
-            if (!shader_create(scene->gl, &scene->shaders.data[i+1], strdup(cfg->shaders.data[i].name), cfg->shaders.data[i].vertex, cfg->shaders.data[i].fragment)) {
+            if (!shader_create(scene->gl, &scene->shaders.data[i + 1],
+                               strdup(cfg->shaders.data[i].name), cfg->shaders.data[i].vertex,
+                               cfg->shaders.data[i].fragment)) {
                 ww_log(LOG_ERROR, "error creating %s shader", cfg->shaders.data[i].name);
                 server_gl_exit(scene->gl);
                 goto fail_compile_texture_copy;

--- a/waywall/server/gl.c
+++ b/waywall/server/gl.c
@@ -1,5 +1,6 @@
 #include "server/gl.h"
 #include "linux-dmabuf-v1-client-protocol.h"
+#include "scene.h"
 #include "server/backend.h"
 #include "server/buffer.h"
 #include "server/server.h"
@@ -9,7 +10,6 @@
 #include "util/alloc.h"
 #include "util/log.h"
 #include "util/prelude.h"
-#include "scene.h"
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <spng.h>

--- a/waywall/server/gl.c
+++ b/waywall/server/gl.c
@@ -9,6 +9,7 @@
 #include "util/alloc.h"
 #include "util/log.h"
 #include "util/prelude.h"
+#include "scene.h"
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <spng.h>
@@ -447,6 +448,7 @@ gl_buffer_import(struct server_gl *gl, struct server_buffer *buffer) {
     return gl_buffer;
 
 fail_image_target:
+    glDeleteTextures(1, &gl_buffer->texture);
 fail_make_current:
     gl_buffer->gl->egl.DestroyImageKHR(gl_buffer->gl->egl.display, gl_buffer->image);
 
@@ -487,6 +489,12 @@ compile_program(GLuint *out, GLuint vert, GLuint frag) {
 
     glAttachShader(prog, vert);
     glAttachShader(prog, frag);
+
+    glBindAttribLocation(prog, SHADER_SRC_POS_ATTRIB_LOC, "v_src_pos");
+    glBindAttribLocation(prog, SHADER_DST_POS_ATTRIB_LOC, "v_dst_pos");
+    glBindAttribLocation(prog, SHADER_SRC_RGBA_ATTRIB_LOC, "v_src_rgba");
+    glBindAttribLocation(prog, SHADER_DST_RGBA_ATTRIB_LOC, "v_dst_rgba");
+
     glLinkProgram(prog);
 
     GLint status;

--- a/waywall/wrap.c
+++ b/waywall/wrap.c
@@ -533,7 +533,7 @@ wrap_create(struct server *server, struct inotify *inotify, struct config *cfg) 
         goto fail_gl;
     }
 
-    wrap->scene = scene_create(wrap->gl, server->ui);
+    wrap->scene = scene_create(cfg, wrap->gl, server->ui);
     if (!wrap->scene) {
         ww_log(LOG_ERROR, "failed to create scene");
         goto fail_scene;


### PR DESCRIPTION
This adds a new config field `shaders` in which you can add custom shaders:

```lua
shaders = {
    ["pie_chart"] = {
        fragment = read_file("pie_chart.frag"),
        vertex = read_file("pie_chart.vert"),
    },
},
```

Which you can then reference in mirrors, images, and text:

```lua
mirror = waywall.mirror({
    src = { x = 130, y = 7902, w = 60, h = 580 },
    dst = { x = 12, y = 484, w = 768, h = 432 },
    shader = "pie_chart",
})
```

This includes a breaking change for `image`. Before:

```lua
image = waywall.image(BOAT_OVERLAY_FILE, { x = 12, y = 484, w = 768, h = 432 })
```

Now:

```lua
image = waywall.image(BOAT_OVERLAY_FILE, {
    dst = { x = 12, y = 484, w = 768, h = 432 },
    shader = "pie_chart",
})
```

`waywall.text()` now has 6 arguments. It might be a good idea to move to an options dictionary like the other APIs.
