### PR TITLE
Xwayland socket rework

### DIFF
--- a/include/server/xserver.h
+++ b/include/server/xserver.h
@@ -10,6 +10,7 @@ struct xserver {
     struct wl_client *client;
 
     int display;
+    char display_name[16];
 
     int fd_xwm[2];
     int fd_wl[2];

--- a/include/server/xwayland.h
+++ b/include/server/xwayland.h
@@ -17,10 +17,6 @@ struct server_xwayland {
 
     struct wl_listener on_display_destroy;
     struct wl_listener on_ready;
-
-    struct {
-        struct wl_signal ready;
-    } events;
 };
 
 struct server_xwayland *server_xwayland_create(struct server *server,

--- a/include/server/xwm.h
+++ b/include/server/xwm.h
@@ -15,6 +15,7 @@ enum xwm_atom {
     WL_SURFACE_ID,
     WL_SURFACE_SERIAL,
     WM_DELETE_WINDOW,
+    WM_S0,
 
     ATOM_COUNT,
 };

--- a/waywall/server/xserver.c
+++ b/waywall/server/xserver.c
@@ -317,6 +317,17 @@ get_display(int x_sockets[static 2]) {
 }
 
 static void
+unlink_display(int display) {
+    char path[64];
+
+    snprintf(path, STATIC_ARRLEN(path), X11_SOCKET_FMT, display);
+    unlink(path);
+
+    snprintf(path, STATIC_ARRLEN(path), X11_LOCK_FMT, display);
+    unlink(path);
+}
+
+static void
 xserver_exec(struct xserver *srv, int notify_fd, int log_fd, int x_sockets[static 2]) {
     // This function should only ever be run in the context of the child process created from
     // `xserver_start`.
@@ -498,6 +509,7 @@ fail_pidfd:
 fail_fork:
     safe_close(x_sockets[1]);
     safe_close(x_sockets[0]);
+    unlink_display(srv->display);
 
 fail_sockets:
     safe_close(log_fd);
@@ -574,6 +586,8 @@ xserver_destroy(struct xserver *srv) {
         }
         close(srv->pidfd);
     }
+
+    unlink_display(srv->display);
 
     free(srv);
 }

--- a/waywall/server/xserver.c
+++ b/waywall/server/xserver.c
@@ -402,6 +402,8 @@ xserver_exec(struct xserver *srv, int notify_fd, int log_fd, int x_sockets[stati
         ww_log_errno(LOG_ERROR, "failed to dup log_fd to stderr");
     }
 
+    close(log_fd);
+
     ww_assert(close(STDIN_FILENO) == 0);
 
     execvp(argv[0], argv);

--- a/waywall/server/xwayland.c
+++ b/waywall/server/xwayland.c
@@ -119,7 +119,7 @@ on_ready(struct wl_listener *listener, void *data) {
         return;
     }
 
-    wl_signal_emit_mutable(&xwl->events.ready, NULL);
+    ww_log(LOG_INFO, "initialized X11 window manager");
 }
 
 static void
@@ -148,8 +148,6 @@ server_xwayland_create(struct server *server, struct server_xwayland_shell *shel
         free(xwl);
         return NULL;
     }
-
-    wl_signal_init(&xwl->events.ready);
 
     xwl->on_ready.notify = on_ready;
     wl_signal_add(&xwl->xserver->events.ready, &xwl->on_ready);

--- a/waywall/server/xwm.c
+++ b/waywall/server/xwm.c
@@ -181,6 +181,7 @@ static const char *atom_names[] = {
     [WL_SURFACE_ID] = "WL_SURFACE_ID",
     [WL_SURFACE_SERIAL] = "WL_SURFACE_SERIAL",
     [WM_DELETE_WINDOW] = "WM_DELETE_WINDOW",
+    [WM_S0] = "WM_S0",
 };
 
 static void
@@ -945,6 +946,8 @@ init_ewmh(struct xwm *xwm) {
 
     xcb_change_property(xwm->conn, XCB_PROP_MODE_REPLACE, xwm->screen->root,
                         xwm->atoms[NET_SUPPORTED], XCB_ATOM_ATOM, 32, 0, NULL);
+
+    xcb_set_selection_owner(xwm->conn, xwm->ewmh_window, xwm->atoms[WM_S0], XCB_CURRENT_TIME);
 }
 
 struct xwm *


### PR DESCRIPTION
This PR opens the Xwayland sockets manually instead of letting the X server take care of it. This fixes the issue where opening waywall on Hyprland would cause it to "steal" Hyprland's X display due to some questionable behavior in xserver and libxtrans (not checking lock files) and the lack of an abstract X11 socket.

I do not enjoy the complete and utter lack of any documentation on how to start up Xwayland or really make use of it at all but hopefully this is the last time I have to touch the X server initialization code (clueless)