### PR TITLE
seat: send modifiers on config reload

### DIFF
--- a/include/server/wl_seat.h
+++ b/include/server/wl_seat.h
@@ -100,6 +100,7 @@ struct server_seat *server_seat_create(struct server *server, struct config *cfg
 void server_seat_send_click(struct server_seat *seat, struct server_view *view);
 void server_seat_send_keys(struct server_seat *seat, struct server_view *view, size_t num_keys,
                            const struct syn_key[static num_keys]);
+void send_keyboard_modifiers(struct server_seat *seat);
 void server_seat_set_listener(struct server_seat *seat, const struct server_seat_listener *listener,
                               void *data);
 void server_seat_use_config(struct server_seat *seat, struct server_seat_config *config);

--- a/waywall/server/wl_seat.c
+++ b/waywall/server/wl_seat.c
@@ -273,7 +273,7 @@ send_keyboard_leave(struct server_seat *seat) {
     }
 }
 
-static void
+void
 send_keyboard_modifiers(struct server_seat *seat) {
     if (!seat->input_focus) {
         return;

--- a/waywall/wrap.c
+++ b/waywall/wrap.c
@@ -645,6 +645,7 @@ wrap_set_config(struct wrap *wrap, struct config *cfg) {
         floating_update_anchored(wrap);
     }
 
+    send_keyboard_modifiers(wrap->server->seat);
     return 0;
 }
 


### PR DESCRIPTION
this prevents ninjabrain bot from thinking a modifier key is held down