### PR TITLE
main: remove redundant struct_sched_param.h include

### DIFF
--- a/waywall/main.c
+++ b/waywall/main.c
@@ -10,7 +10,6 @@
 #include "util/syscall.h"
 #include "util/sysinfo.h"
 #include "wrap.h"
-#include <bits/types/struct_sched_param.h>
 #include <errno.h>
 #include <sched.h>
 #include <signal.h>


### PR DESCRIPTION
`struct sched_param` is guaranteed by POSIX to be defined in `<sched.h>`. `<bits/types/struct_sched_param.h>` is a glibc-only header file that prevents the program from building on non-glibc systems.