### PR TITLE
Define XKB_MOD_NAME_* constants for libxkbcompat 1.7.0

### DIFF
--- a/waywall/server/wl_seat.c
+++ b/waywall/server/wl_seat.c
@@ -33,6 +33,27 @@ struct key_update {
     bool changed_modifiers;
 };
 
+// Required to build on Debian 13 (which ships libxkbcompat 1.7.0)
+#ifndef XKB_MOD_NAME_MOD1
+#define XKB_MOD_NAME_MOD1 XKB_MOD_NAME_ALT
+#endif
+
+#ifndef XKB_MOD_NAME_MOD2
+#define XKB_MOD_NAME_MOD2 XKB_MOD_NAME_NUM
+#endif
+
+#ifndef XKB_MOD_NAME_MOD3
+#define XKB_MOD_NAME_MOD3 "Mod3"
+#endif
+
+#ifndef XKB_MOD_NAME_MOD4
+#define XKB_MOD_NAME_MOD4 XKB_MOD_NAME_LOGO
+#endif
+
+#ifndef XKB_MOD_NAME_MOD5
+#define XKB_MOD_NAME_MOD5 "Mod5"
+#endif
+
 static const char *mod_names[] = {
     XKB_MOD_NAME_SHIFT, XKB_MOD_NAME_CAPS, XKB_MOD_NAME_CTRL, XKB_MOD_NAME_MOD1,
     XKB_MOD_NAME_MOD2,  XKB_MOD_NAME_MOD3, XKB_MOD_NAME_MOD4, XKB_MOD_NAME_MOD5,


### PR DESCRIPTION
This allows for building on Debian 13 where libxkbcompat 1.7.0 is shipped which is missing a couple of modifier keys.