### PR TITLE
server, wrap: support X11 Minecraft

### DIFF
--- a/include/wrap.h
+++ b/include/wrap.h
@@ -19,7 +19,6 @@ struct wrap {
 
     int32_t width, height;
     bool is_fullscreen;
-    bool allow_mc_x11;
 
     struct server_view *view;
     struct instance *instance;
@@ -44,6 +43,13 @@ struct wrap {
         double x, y;
     } input;
 
+    struct {
+        struct wl_event_loop *loop;
+        struct wl_event_source *fullscreen_timeout;
+
+        bool allow_x11, is_x11;
+    } legacy; // LWJGL2 quarantine
+
     struct wl_listener on_close;
     struct wl_listener on_pointer_lock;
     struct wl_listener on_pointer_unlock;
@@ -52,8 +58,8 @@ struct wrap {
     struct wl_listener on_view_destroy;
 };
 
-struct wrap *wrap_create(struct server *server, struct inotify *inotify, struct ww_timer *timer,
-                         struct config *cfg, bool allow_mc_x11);
+struct wrap *wrap_create(struct wl_event_loop *loop, struct server *server, struct inotify *inotify,
+                         struct ww_timer *timer, struct config *cfg, bool allow_mc_x11);
 void wrap_destroy(struct wrap *wrap);
 int wrap_set_config(struct wrap *wrap, struct config *cfg);
 

--- a/waywall/main.c
+++ b/waywall/main.c
@@ -116,7 +116,7 @@ cmd_wrap(const char *profile, bool allow_mc_x11, char **argv) {
 
     ww.timer = ww_timer_create(ww.server);
 
-    ww.wrap = wrap_create(ww.server, ww.inotify, ww.timer, ww.cfg, allow_mc_x11);
+    ww.wrap = wrap_create(loop, ww.server, ww.inotify, ww.timer, ww.cfg, allow_mc_x11);
     if (!ww.wrap) {
         goto fail_wrap;
     }

--- a/waywall/server/gl.c
+++ b/waywall/server/gl.c
@@ -740,7 +740,8 @@ server_gl_get_capture_size(struct server_gl *gl, int32_t *width, int32_t *height
 void
 server_gl_set_capture(struct server_gl *gl, struct server_surface *surface) {
     if (gl->capture.surface) {
-        ww_panic("cannot overwrite capture surface");
+        // TODO: Check that this is the result of LWJGL2 fullscreen (see wrap.legacy)
+        ww_log(LOG_WARN, "overwrote capture surface");
     }
 
     gl->capture.surface = surface;

--- a/waywall/wrap.c
+++ b/waywall/wrap.c
@@ -30,6 +30,8 @@
 #include <wayland-util.h>
 #include <xkbcommon/xkbcommon.h>
 
+#define X11_FS_TIMEOUT 100
+
 #define IS_ANCHORED(wrap, view) (wrap->floating.anchored == view)
 #define SHOULD_ANCHOR(wrap) (wrap->cfg->theme.ninb_anchor != ANCHOR_NONE)
 
@@ -266,6 +268,23 @@ process_state_update(int wd, uint32_t mask, const char *name, void *data) {
     config_vm_signal_event(wrap->cfg->vm, "state");
 }
 
+static int
+on_fullscreen_timeout(void *data) {
+    struct wrap *wrap = data;
+
+    // If the fullscreen timeout expires and there is still no new view to take the previous one's
+    // place, shut down.
+    if (!wrap->view) {
+        server_ui_hide(wrap->server->ui);
+        server_shutdown(wrap->server);
+    }
+
+    wl_event_source_remove(wrap->legacy.fullscreen_timeout);
+    wrap->legacy.fullscreen_timeout = NULL;
+
+    return 0;
+}
+
 static void
 on_anchored_resize(struct wl_listener *listener, void *data) {
     struct wrap_floating *wrap_floating =
@@ -342,8 +361,9 @@ on_view_create(struct wl_listener *listener, void *data) {
         return;
     }
 
-    if (strcmp(view->impl->name, "xwayland") == 0) {
-        if (wrap->allow_mc_x11) {
+    if (!wrap->legacy.is_x11 && strcmp(view->impl->name, "xwayland") == 0) {
+        if (wrap->legacy.allow_x11) {
+            wrap->legacy.is_x11 = true;
             ww_log(LOG_WARN, "X11 minecraft instance detected but allowed");
         } else {
             // clang-format off
@@ -398,7 +418,11 @@ on_view_create(struct wl_listener *listener, void *data) {
     wrap->server->ui->height = height;
 
     server_set_input_focus(wrap->server, wrap->view);
-    server_ui_show(wrap->server->ui);
+
+    // HACK: Due to LWJGL2 fullscreen shenanigans, the UI may already be visible.
+    if (!wrap->server->ui->mapped) {
+        server_ui_show(wrap->server->ui);
+    }
 
     ww_assert(wrap->width > 0 && wrap->height > 0);
     ww_assert(wrap->view);
@@ -430,9 +454,29 @@ on_view_destroy(struct wl_listener *listener, void *data) {
         wrap->instance = NULL;
     }
 
+    // HACK: For SOME REASON, the LWJGL2 developers decided that the best course of action to take
+    // when (un)fullscreening a window is to delete it and make a new one. So, if the user might be
+    // running an older instance, we should wait for a short timeout to see if a new window is
+    // created right after the main instance was destroyed. Otherwise, waywall can shut down
+    // immediately when the Minecraft window closes.
     wrap->view = NULL;
-    server_ui_hide(wrap->server->ui);
-    server_shutdown(wrap->server);
+
+    if (!wrap->legacy.is_x11) {
+        server_ui_hide(wrap->server->ui);
+        server_shutdown(wrap->server);
+        return;
+    }
+
+    ww_assert(!wrap->legacy.fullscreen_timeout);
+    wrap->legacy.fullscreen_timeout =
+        wl_event_loop_add_timer(wrap->legacy.loop, on_fullscreen_timeout, wrap);
+    check_alloc(wrap->legacy.fullscreen_timeout);
+
+    if (wl_event_source_timer_update(wrap->legacy.fullscreen_timeout, X11_FS_TIMEOUT) == -1) {
+        ww_log(LOG_ERROR, "failed to start X11 fullscreen timeout timer");
+        server_ui_hide(wrap->server->ui);
+        server_shutdown(wrap->server);
+    }
 }
 
 static bool
@@ -562,10 +606,12 @@ static const struct server_seat_listener seat_listener = {
 };
 
 struct wrap *
-wrap_create(struct server *server, struct inotify *inotify, struct ww_timer *timer,
-            struct config *cfg, bool allow_mc_x11) {
+wrap_create(struct wl_event_loop *loop, struct server *server, struct inotify *inotify,
+            struct ww_timer *timer, struct config *cfg, bool allow_mc_x11) {
     struct wrap *wrap = zalloc(1, sizeof(*wrap));
-    wrap->allow_mc_x11 = allow_mc_x11;
+
+    wrap->legacy.loop = loop;
+    wrap->legacy.allow_x11 = allow_mc_x11;
 
     wrap->gl = server_gl_create(server);
     if (!wrap->gl) {
@@ -622,6 +668,10 @@ fail_gl:
 
 void
 wrap_destroy(struct wrap *wrap) {
+    if (wrap->legacy.fullscreen_timeout) {
+        wl_event_source_remove(wrap->legacy.fullscreen_timeout);
+    }
+
     if (wrap->instance) {
         instance_destroy(wrap->instance);
     }


### PR DESCRIPTION
This pull request contains some bugfixes and janky workarounds for getting the game to work when run under X11 (either on LWJGL2, which is present in older versions, or on X11 GLFW, which is present in newer versions.)

I don't plan on merging this in its current state since the code is not very good and there are still some lingering issues which should be resolvable with improvements to other parts of the codebase (primarily how fullscreen is handled.)