### PR TITLE
add configurable fullscreen resolution

### DIFF
--- a/include/config/config.h
+++ b/include/config/config.h
@@ -13,6 +13,11 @@ struct config {
     } experimental;
 
     struct {
+        int32_t fullscreen_width;
+        int32_t fullscreen_height;
+    } window;
+
+    struct {
         struct {
             char *layout;
             char *model;

--- a/include/server/gl.h
+++ b/include/server/gl.h
@@ -38,6 +38,7 @@ struct server_gl {
     struct {
         struct wl_surface *remote;
         struct wl_subsurface *subsurface;
+        struct wp_viewport *viewport;
         struct wl_egl_window *window;
         EGLSurface egl;
     } surface;

--- a/include/server/ui.h
+++ b/include/server/ui.h
@@ -31,6 +31,8 @@ struct server_ui {
     struct zxdg_toplevel_decoration_v1 *xdg_decoration;
 
     int32_t width, height;
+    int32_t render_width, render_height;
+    int32_t fullscreen_width, fullscreen_height;
     bool mapped, resize, fullscreen;
 
     struct wl_list views; // server_view.link
@@ -46,6 +48,9 @@ struct server_ui {
 struct server_ui_config {
     struct wl_buffer *background;
     bool tearing;
+
+    int32_t fullscreen_width;
+    int32_t fullscreen_height;
 
     uint32_t ninb_opacity;
 };

--- a/waywall/scene.c
+++ b/waywall/scene.c
@@ -141,8 +141,8 @@ image_render(struct scene_object *object) {
     struct scene *scene = image->parent;
 
     server_gl_shader_use(scene->shaders.data[image->shader_index].shader);
-    glUniform2f(scene->shaders.data[image->shader_index].shader_u_dst_size, scene->ui->width,
-                scene->ui->height);
+    glUniform2f(scene->shaders.data[image->shader_index].shader_u_dst_size, scene->ui->render_width,
+                scene->ui->render_height);
     glUniform2f(scene->shaders.data[image->shader_index].shader_u_src_size, image->width,
                 image->height);
 
@@ -200,8 +200,8 @@ mirror_render(struct scene_object *object) {
     server_gl_get_capture_size(scene->gl, &width, &height);
 
     server_gl_shader_use(scene->shaders.data[mirror->shader_index].shader);
-    glUniform2f(scene->shaders.data[mirror->shader_index].shader_u_dst_size, scene->ui->width,
-                scene->ui->height);
+    glUniform2f(scene->shaders.data[mirror->shader_index].shader_u_dst_size,
+                scene->ui->render_width, scene->ui->render_height);
     glUniform2f(scene->shaders.data[mirror->shader_index].shader_u_src_size, width, height);
 
     gl_using_buffer(GL_ARRAY_BUFFER, mirror->vbo) {
@@ -285,8 +285,8 @@ text_render(struct scene_object *object) {
     struct scene *scene = text->parent;
 
     server_gl_shader_use(scene->shaders.data[text->shader_index].shader);
-    glUniform2f(scene->shaders.data[text->shader_index].shader_u_dst_size, scene->ui->width,
-                scene->ui->height);
+    glUniform2f(scene->shaders.data[text->shader_index].shader_u_dst_size, scene->ui->render_width,
+                scene->ui->render_height);
     glUniform2f(scene->shaders.data[text->shader_index].shader_u_src_size, ATLAS_WIDTH,
                 ATLAS_HEIGHT);
 
@@ -408,8 +408,8 @@ draw_stencil(struct scene *scene) {
     // draw_frame. This stuff really should be synchronized with the surface content. Might be worth
     // always doing compositing if scene objects are visible but I'm not very happy with that
     // solution.
-    bool stencil_equal = scene->ui->width == scene->prev_frame.width &&
-                         scene->ui->height == scene->prev_frame.height &&
+    bool stencil_equal = scene->ui->render_width == scene->prev_frame.width &&
+                         scene->ui->render_height == scene->prev_frame.height &&
                          width == scene->prev_frame.tex_width &&
                          height == scene->prev_frame.tex_height;
     if (stencil_equal) {
@@ -419,8 +419,8 @@ draw_stencil(struct scene *scene) {
         }
     }
 
-    scene->prev_frame.width = scene->ui->width;
-    scene->prev_frame.height = scene->ui->height;
+    scene->prev_frame.width = scene->ui->render_width;
+    scene->prev_frame.height = scene->ui->render_height;
     scene->prev_frame.tex_width = width;
     scene->prev_frame.tex_height = height;
     scene->prev_frame.equal_frames = 0;
@@ -436,8 +436,8 @@ draw_stencil(struct scene *scene) {
     glStencilOp(GL_REPLACE, GL_REPLACE, GL_REPLACE);
 
     struct box dst = {
-        .x = (scene->ui->width / 2) - (width / 2),
-        .y = (scene->ui->height / 2) - (height / 2),
+        .x = (scene->ui->render_width / 2) - (width / 2),
+        .y = (scene->ui->render_height / 2) - (height / 2),
         .width = width,
         .height = height,
     };
@@ -461,7 +461,8 @@ static void
 draw_debug_text(struct scene *scene) {
     // The OpenGL context must be current.
     server_gl_shader_use(scene->shaders.data[0].shader);
-    glUniform2f(scene->shaders.data[0].shader_u_dst_size, scene->ui->width, scene->ui->height);
+    glUniform2f(scene->shaders.data[0].shader_u_dst_size, scene->ui->render_width,
+                scene->ui->render_height);
     glUniform2f(scene->shaders.data[0].shader_u_src_size, ATLAS_WIDTH, ATLAS_HEIGHT);
 
     const char *str = util_debug_str();
@@ -495,7 +496,7 @@ draw_frame(struct scene *scene) {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    glViewport(0, 0, scene->ui->width, scene->ui->height);
+    glViewport(0, 0, scene->ui->render_width, scene->ui->render_height);
 
     if (!should_draw_frame(scene)) {
         // TODO: Scene rendering could potentially be synchronized with the game subsurface (or

--- a/waywall/wrap.c
+++ b/waywall/wrap.c
@@ -123,8 +123,11 @@ floating_update_anchored(struct wrap *wrap) {
     int32_t win_width, win_height;
     server_buffer_get_size(buffer, &win_width, &win_height);
 
-    uint32_t center_x = (wrap->width / 2) - (win_width / 2);
-    uint32_t center_y = (wrap->height / 2) - (win_height / 2);
+    int32_t ui_width = wrap->server->ui->width;
+    int32_t ui_height = wrap->server->ui->height;
+
+    uint32_t center_x = (ui_width / 2) - (win_width / 2);
+    uint32_t center_y = (ui_height / 2) - (win_height / 2);
 
     uint32_t x, y;
 
@@ -138,7 +141,7 @@ floating_update_anchored(struct wrap *wrap) {
         y = 0;
         break;
     case ANCHOR_TOPRIGHT:
-        x = wrap->width - win_width;
+        x = ui_width - win_width;
         y = 0;
         break;
     case ANCHOR_LEFT:
@@ -146,16 +149,16 @@ floating_update_anchored(struct wrap *wrap) {
         y = center_y;
         break;
     case ANCHOR_RIGHT:
-        x = wrap->width - win_width;
+        x = ui_width - win_width;
         y = center_y;
         break;
     case ANCHOR_BOTTOMLEFT:
         x = 0;
-        y = wrap->height - win_height;
+        y = ui_height - win_height;
         break;
     case ANCHOR_BOTTOMRIGHT:
-        x = wrap->width - win_width;
-        y = wrap->height - win_height;
+        x = ui_width - win_width;
+        y = ui_height - win_height;
         break;
     default:
         // Silence release mode compiler warnings.
@@ -301,8 +304,8 @@ static void
 on_resize(struct wl_listener *listener, void *data) {
     struct wrap *wrap = wl_container_of(listener, wrap, on_resize);
 
-    int32_t new_width = wrap->server->ui->width;
-    int32_t new_height = wrap->server->ui->height;
+    int32_t new_width = wrap->server->ui->render_width;
+    int32_t new_height = wrap->server->ui->render_height;
 
     if (new_width == wrap->width && new_height == wrap->height) {
         return;
@@ -324,7 +327,8 @@ on_resize(struct wl_listener *listener, void *data) {
         floating_update_anchored(wrap);
     }
 
-    server_set_pointer_pos(wrap->server, wrap->width / 2.0, wrap->height / 2.0);
+    server_set_pointer_pos(wrap->server, wrap->server->ui->width / 2.0,
+                           wrap->server->ui->height / 2.0);
 }
 
 static void
@@ -398,6 +402,7 @@ on_view_create(struct wl_listener *listener, void *data) {
     ww_assert(wrap->width > 0 && wrap->height > 0);
     ww_assert(wrap->view);
 
+    server_view_set_size(wrap->view, wrap->width, wrap->height);
     server_view_set_centered(wrap->view, true);
     server_view_set_visible(wrap->view, true);
     server_view_commit(wrap->view);


### PR DESCRIPTION
Adds support for explicitly configuring fullscreen resolution, ex:
```
local config = {
    window = {
      fullscreen_width = 1920,
      fullscreen_height = 1080
    }
}
```
Also looking into https://wayland.app/protocols/fractional-scale-v1, but not sure what more that would add.