### PR TITLE
use %{_libdir} instead of /usr/local/lib64/

### DIFF
--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -33,10 +33,10 @@ package() {
     cp -r doc "$pkgdir/usr/share/doc/$pkgname/"
   fi
   #GLFW
-  mkdir -p "$pkgdir/usr/local/lib64/waywall-glfw"
-  install -m644 waywall-build/glfw/libglfw.so "$pkgdir/usr/local/lib64/waywall-glfw/"
-  install -m644 waywall-build/glfw/libglfw.so.3 "$pkgdir/usr/local/lib64/waywall-glfw/"
-  install -m644 waywall-build/glfw/libglfw.so.3.4 "$pkgdir/usr/local/lib64/waywall-glfw/"
+  mkdir -p "$pkgdir/usr/lib64/waywall-glfw"
+  install -m644 waywall-build/glfw/libglfw.so "$pkgdir/usr/lib64/waywall-glfw/"
+  install -m644 waywall-build/glfw/libglfw.so.3 "$pkgdir/usr/lib64/waywall-glfw/"
+  install -m644 waywall-build/glfw/libglfw.so.3.4 "$pkgdir/usr/lib64/waywall-glfw/"
   #GLFW-DOCS
   install -m644 waywall-build/glfw/LICENSE.md "$pkgdir/usr/share/doc/$pkgname/glfw-LICENSE.md"
   install -m644 waywall-build/glfw/CONTRIBUTORS.md "$pkgdir/usr/share/doc/$pkgname/glfw-CONTRIBUTORS.md"

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -16,17 +16,17 @@ override_dh_auto_install:
 	install -d $(CURDIR)/debian/waywall/usr/share/licenses/waywall
 	install -m 644 LICENSE $(CURDIR)/debian/waywall/usr/share/licenses/waywall/LICENSE
 	if [ -d doc ]; then cp -r doc $(CURDIR)/debian/waywall/usr/share/doc/waywall/; fi
-	install -d $(CURDIR)/debian/waywall/usr/local/lib64/waywall-glfw
-	install -m644 waywall-build/glfw/libglfw.so $(CURDIR)/debian/waywall/usr/local/lib64/waywall-glfw/
-	install -m644 waywall-build/glfw/libglfw.so.3 $(CURDIR)/debian/waywall/usr/local/lib64/waywall-glfw/
-	install -m644 waywall-build/glfw/libglfw.so.3.4 $(CURDIR)/debian/waywall/usr/local/lib64/waywall-glfw/
+	install -d $(CURDIR)/debian/waywall/usr/lib64/waywall-glfw
+	install -m644 waywall-build/glfw/libglfw.so $(CURDIR)/debian/waywall/usr/lib64/waywall-glfw/
+	install -m644 waywall-build/glfw/libglfw.so.3 $(CURDIR)/debian/waywall/usr/lib64/waywall-glfw/
+	install -m644 waywall-build/glfw/libglfw.so.3.4 $(CURDIR)/debian/waywall/usr/lib64/waywall-glfw/
 	install -m644 waywall-build/glfw/LICENSE.md $(CURDIR)/debian/waywall/usr/share/doc/waywall/glfw-LICENSE.md
 	install -m644 waywall-build/glfw/CONTRIBUTORS.md $(CURDIR)/debian/waywall/usr/share/doc/waywall/glfw-CONTRIBUTORS.md
 	install -m644 waywall-build/glfw/MAINTAINERS.md $(CURDIR)/debian/waywall/usr/share/doc/waywall/glfw-MAINTAINERS.md
 	
 
     # Ensure the directories are created
-	ls -la $(CURDIR)/debian/waywall/usr/local/lib64/waywall-glfw || true
+	ls -la $(CURDIR)/debian/waywall/usr/lib64/waywall-glfw || true
 	ls -la $(CURDIR)/debian/waywall/usr/bin/ || true
 	ls -la $(CURDIR)/debian/waywall/usr/share/doc/waywall/ || true
 	ls -la $(CURDIR)/debian/waywall/usr/share/licenses/waywall/ || true

--- a/contrib/waywall.spec
+++ b/contrib/waywall.spec
@@ -46,13 +46,13 @@ fi
 install -Dm644 %{_sourcedir}/LICENSE %{buildroot}%{_datarootdir}/licenses/%{name}/LICENSE
 
 # Install patched GLFW libraries from source directory
-mkdir -p %{buildroot}%{_prefix}/local/lib64/waywall-glfw
+mkdir -p %{buildroot}%{_libdir}/waywall-glfw/
 for file in %{_sourcedir}/waywall-build/glfw/libglfw.so %{_sourcedir}/waywall-build/glfw/libglfw.so.3 %{_sourcedir}/waywall-build/glfw/libglfw.so.3.4; do
     if [ ! -f "$file" ]; then
         echo "Error: $file not found"
         exit 1
     fi
-    install -m644 "$file" %{buildroot}%{_prefix}/local/lib64/waywall-glfw/
+    install -m644 "$file" %{buildroot}%{_libdir}/waywall-glfw/
 done
 
 # Install GLFW documentation from source directory with glfw- prefix
@@ -77,7 +77,7 @@ fi
 %doc %{_docdir}/%{name}/glfw-MAINTAINERS.md
 %doc %{_docdir}/%{name}/doc/*
 %{_bindir}/waywall
-%{_prefix}/local/lib64/waywall-glfw/*
+%{_libdir}/waywall-glfw/*
 
 %post
 

--- a/doc/00_setup.md
+++ b/doc/00_setup.md
@@ -21,7 +21,7 @@ GLFW.
 > [!TIP]
 > If you used a [prebuilt package] or built your own with the package building
 > script, then you already have the correct version of GLFW available! It can be
-> found at `/usr/local/lib64/waywall-glfw/libglfw.so`.
+> found at `/usr/lib64/waywall-glfw/libglfw.so`.
 
 > [!TIP]
 > If you are using Prism Launcher installed from Nixpkgs, you can skip and 


### PR DESCRIPTION
After attempting to install the packages with rpm-ostree, I found that it does not support /usr/local. Then I found that the spec file does not use the _libdir macro, which is probably more correct to use

I also adjusted the other packages to be in-line with this new libglfw path