### PR TITLE
fix: reset SCHED_RR in child processes before exec

### DIFF
--- a/waywall/main.c
+++ b/waywall/main.c
@@ -136,6 +136,9 @@ cmd_wrap(const char *profile, bool allow_mc_x11, char **argv) {
     ww.child = fork();
 
     if (ww.child == 0) {
+        // Reset scheduling policy so the child does not inherit SCHED_RR.
+        sched_setscheduler(0, SCHED_OTHER, &(struct sched_param){.sched_priority = 0});
+
         if (env) {
             ww_log(LOG_INFO, "starting child process with passthrough environment");
             util_execvpe(argv[0], argv, env);

--- a/waywall/server/xserver.c
+++ b/waywall/server/xserver.c
@@ -7,6 +7,7 @@
 #include "util/syscall.h"
 #include <errno.h>
 #include <fcntl.h>
+#include <sched.h>
 #include <signal.h>
 #include <stdio.h>
 #include <sys/socket.h>
@@ -452,6 +453,7 @@ xserver_start(struct xserver *srv) {
     srv->pid = fork();
     if (srv->pid == 0) {
         // Child process
+        sched_setscheduler(0, SCHED_OTHER, &(struct sched_param){.sched_priority = 0});
         xserver_exec(srv, notify_fd[1], log_fd);
         exit(EXIT_FAILURE);
     } else if (srv->pid == -1) {

--- a/waywall/subproc.c
+++ b/waywall/subproc.c
@@ -5,6 +5,7 @@
 #include "util/log.h"
 #include "util/syscall.h"
 #include <fcntl.h>
+#include <sched.h>
 #include <stdlib.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -85,6 +86,8 @@ subproc_exec(struct subproc *subproc, struct strs cmd) {
     pid_t pid = fork();
     if (pid == 0) {
         // Child process
+        sched_setscheduler(0, SCHED_OTHER, &(struct sched_param){.sched_priority = 0});
+
         int out = open("/dev/null", O_WRONLY);
         if (out == -1) {
             ww_log_errno(LOG_ERROR, "failed to open /dev/null in child process");


### PR DESCRIPTION
Problem:
Waywall starving other process during seed generation (seedqueue wall) causes insane stuttering. 

Specs:
Ryzen 5 5600X, 32GB DDR4 3600MHz, CachyOS, Hyperland, kernel 6.19.5-3-cachyos

Cause:
`set_realtime()` sets `SCHED_RR` on the waywall process for compositor responsiveness. Child processes created via `fork()` inherit this real-time scheduling policy.

When a CPU-heavy workload (e.g. seedqueue seed generation) runs as a child with `SCHED_RR` and saturates all cores, the kernel always schedules these real-time processes before any `SCHED_OTHER` (normal) process. This starves every other application on the system, causing system-wide stuttering.

Fix:
Reset the scheduling policy to `SCHED_OTHER` in the child branch of all three fork sites before calling `exec`:

- `main.c` — main child process (Minecraft)
- `subproc.c` — Lua `exec()` commands
- `xserver.c` — Xwayland

waywall itself keeps `SCHED_RR`.