### PR TITLE
abort on panic

### DIFF
--- a/waywall/util/prelude.c
+++ b/waywall/util/prelude.c
@@ -13,5 +13,5 @@ util_panic(const char *fmt, ...) {
     fprintf(stderr, "\n");
 
     fflush(stderr);
-    exit(EXIT_FAILURE);
+    abort();
 }


### PR DESCRIPTION
Raising `SIGABRT` generates a core dump, which should help with debugging.