### PR TITLE
docs: add note about 26.1 not requiring GLFW patch

### DIFF
--- a/doc/00_setup.md
+++ b/doc/00_setup.md
@@ -31,6 +31,9 @@ GLFW.
 > install the `glfw3-minecraft` package with `nix profile` and use the path
 > `/home/USER/.nix-profile/lib/libglfw.so` in the upcoming steps.
 
+> [!NOTE]
+> Version 26.1 does not require this patch, instead requiring you to add the java arguments `-DMC_DEBUG_ENABLED -DMC_DEBUG_PREFER_WAYLAND`. 
+
 You can compile the patched version of GLFW with the following commands:
 
 ```sh


### PR DESCRIPTION
adds note from #55 

> [!WARNING]
> https://github.com/user-attachments/assets/4b368c61-e961-4e13-ac75-fedd5b7e2e84

> [!CAUTION]
> https://github.com/user-attachments/assets/520f5dda-7463-4180-ad8b-b23447e1d954