### PR TITLE
waywall: add install to build target

### DIFF
--- a/waywall/meson.build
+++ b/waywall/meson.build
@@ -55,4 +55,5 @@ executable('waywall',
 
   dependencies: waywall_deps,
   include_directories: includes,
+  install: true,
 )


### PR DESCRIPTION
its recommended to add this to executables that are meant to be installed/used, also eases future package maintenance

ref: https://github.com/laineu/gentoo-overlay/blob/ed54e7b7a0b192bd746319f98362cbb30291db2f/gui-wm/waywall/waywall-0.2026.02.06.ebuild#L44