### PR TITLE
lua: iterate over elements deterministically

### DIFF
--- a/waywall/lua/api.lua
+++ b/waywall/lua/api.lua
@@ -36,11 +36,10 @@ local function event_handler(name)
     end
 end
 
-local events = {
-    ["load"] = event_handler("load"),
-    ["resolution"] = event_handler("resolution"),
-    ["state"] = event_handler("state"),
-}
+local events = {}
+events.load         = event_handler("load")
+events.resolution   = event_handler("resolution")
+events.state        = event_handler("state")
 
 local M = {}
 

--- a/waywall/lua/init.lua
+++ b/waywall/lua/init.lua
@@ -184,7 +184,11 @@ if user_config.autogen then
 
     local waywall = require("waywall")
     waywall.listen("load", function()
-        autogen_text = waywall.text(autogen_notice, { x = 10, y = 10, size = 1 })
+        sizexy = {}
+        sizexy.x    = 10
+        sizexy.y    = 10
+        sizexy.size = 1
+        autogen_text = waywall.text(autogen_notice, sizexy)
     end)
 end
 


### PR DESCRIPTION
lua: iterate over elements deterministically
to allow for reproducible builds.
See https://reproducible-builds.org/ for why this is good.

Without this patch, `/usr/bin/waywall` had variations in the order of strings "`load`", "`state`"

This patch was done while working on reproducible builds for openSUSE.

Note: I don't know lua well and only tested that it builds and binary/string diffs look sane.