### PR TITLE
fix ordering issue with objects with both negative and positive depth

### DIFF
--- a/waywall/scene.c
+++ b/waywall/scene.c
@@ -546,6 +546,9 @@ draw_frame(struct scene *scene) {
     if (positive_depth) {
         wl_list_for_each (object, positive_depth, link) {
             object_render(object);
+            if (object->link.next == &scene->objects.sorted) {
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
I noticed that if I have images with positive and negative depth some images with negative depth were rendered on top of minecraft. After looking into it a bit I figured out that the issue is with the wl_list_for_each macro that goes through all objects with positive depth. The end condition for the loop is `&pos->member != (head)`which expands to `&object->link != (positive_depth)`. As the last element of a wl_list points to the head of the list this causes the loop to wrap around and go through all elements with negative depth until it reaches positive_depth again. In the process it also tries to render the head of the list which should be undefined behaviour.
To test this you just need at least 2 scene objects with negative depth and one with positive. All but one of the objects with negative depth will end up getting rendered on top of the game.

My fix is to just end the loop manually once we reach the head of the list.