### PR TITLE
keyboard shortcuts inhibition

### DIFF
--- a/doc/01_options_window.md
+++ b/doc/01_options_window.md
@@ -10,6 +10,7 @@ local config = {
     window = {
         fullscreen_width = 0,
         fullscreen_height = 0,
+        inhibit_keyboard_shortcuts = false,
     },
 }
 
@@ -27,3 +28,15 @@ at 1440p) but would still like Minecraft to render at a normal resolution.
 
 If either value is 0, then waywall will use whichever resolution the compositor
 tells it to use.
+
+## Inhibiting keyboard shortcuts
+
+The `inhibit_keyboard_shortcuts` allows you to request the host compositor
+to ignore its keyboard shortcuts (like <kbd><kbd>Alt</kbd>+<kbd>Tab</kbd></kbd>
+or <kbd>Super</kbd>) and pass these key events to waywall.
+
+This option requires your compositor to support the
+[keyboard-shortcuts-inhibit-unstable-v1] protocol,
+or else it will have no effect.
+
+[keyboard-shortcuts-inhibit-unstable-v1]: https://wayland.app/protocols/keyboard-shortcuts-inhibit-unstable-v1

--- a/doc/02_waywall_keyboard_shortcuts_inhibited.md
+++ b/doc/02_waywall_keyboard_shortcuts_inhibited.md
@@ -1,0 +1,22 @@
+# keyboard_shortcuts_inhibited
+
+This function checks whether the host compositor's shortcuts are inhibited.
+
+The host compositor may choose to temporarily ignore this inhibition,
+usually by having the user press some special key combination.
+Nevertheless, this function will keep returning `true`, unless the inhibition
+is disabled with [`waywall.set_keyboard_shortcuts_inhibition`]
+or the `inhibit_keyboard_shortcuts` option in the [window configuration table].
+
+If the host compositor doesn't implement
+[keyboard-shortcuts-inhibit-unstable-v1] this will always return `false`.
+
+### Return values
+
+  - `inhibited`: boolean
+
+> This function cannot be called during startup.
+
+[`waywall.set_keyboard_shortcuts_inhibition`]: 02_waywall_set_keyboard_shortcuts_inhibition.md
+[window configuration table]: 01_options_window.md
+[keyboard-shortcuts-inhibit-unstable-v1]: https://wayland.app/protocols/keyboard-shortcuts-inhibit-unstable-v1

--- a/doc/02_waywall_set_keyboard_shortcuts_inhibition.md
+++ b/doc/02_waywall_set_keyboard_shortcuts_inhibition.md
@@ -1,0 +1,14 @@
+# set_keyboard_shortcuts_inhibition
+
+This function enables or disables inhibiting host compositor's shortcuts.
+
+It behaves the same as the `inhibit_keyboard_shortcuts` option
+in the [window configuration table].
+
+### Arguments
+
+  - `inhibit`: boolean
+
+> This function cannot be called during startup.
+
+[window configuration table]: 01_options_window.md

--- a/include/config/config.h
+++ b/include/config/config.h
@@ -15,6 +15,7 @@ struct config {
     struct {
         int32_t fullscreen_width;
         int32_t fullscreen_height;
+        bool inhibit_keyboard_shortcuts;
     } window;
 
     struct {

--- a/include/server/backend.h
+++ b/include/server/backend.h
@@ -38,6 +38,7 @@ struct server_backend {
     struct wp_single_pixel_buffer_manager_v1 *single_pixel_buffer_manager;
     struct wp_tearing_control_manager_v1 *tearing_control;
     struct zxdg_decoration_manager_v1 *xdg_decoration_manager;
+    struct zwp_keyboard_shortcuts_inhibit_manager_v1 *keyboard_shortcuts_inhibit_manager;
 
     struct {
         struct wl_signal seat_data_device; // data: nullptr

--- a/include/server/ui.h
+++ b/include/server/ui.h
@@ -19,6 +19,7 @@ struct server_ui {
         struct wp_viewport *viewport;
 
         struct wp_tearing_control_v1 *tearing_control;
+        struct zwp_keyboard_shortcuts_inhibitor_v1 *keyboard_shortcut_inhibitor;
     } root;
     struct {
         struct wl_buffer *buffer;
@@ -48,6 +49,7 @@ struct server_ui {
 struct server_ui_config {
     struct wl_buffer *background;
     bool tearing;
+    bool inhibit_keyboard_shortcuts;
 
     int32_t fullscreen_width;
     int32_t fullscreen_height;
@@ -103,6 +105,8 @@ struct server_ui *server_ui_create(struct server *server, struct config *cfg);
 void server_ui_destroy(struct server_ui *ui);
 void server_ui_hide(struct server_ui *ui);
 void server_ui_set_fullscreen(struct server_ui *ui, bool fullscreen);
+void server_ui_set_keyboard_shortcuts_inhibition(struct server_ui *ui, bool inhibit);
+bool server_ui_keyboard_shortcuts_inhibited(struct server_ui *ui);
 void server_ui_show(struct server_ui *ui);
 void server_ui_use_config(struct server_ui *ui, struct server_ui_config *config);
 

--- a/include/wrap.h
+++ b/include/wrap.h
@@ -61,3 +61,5 @@ void wrap_lua_press_key(struct wrap *wrap, uint32_t keycode);
 int wrap_lua_set_res(struct wrap *wrap, int32_t width, int32_t height);
 void wrap_lua_show_floating(struct wrap *wrap, bool show);
 void wrap_lua_toggle_fullscreen(struct wrap *wrap);
+void wrap_lua_set_keyboard_shortcuts_inhibition(struct wrap *wrap, bool inhibit);
+bool wrap_lua_keyboard_shortcuts_inhibited(struct wrap *wrap);

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -22,6 +22,7 @@ protocol_xmls = [
   wp_dir + 'unstable/relative-pointer/relative-pointer-unstable-v1.xml',
   wp_dir + 'unstable/tablet/tablet-unstable-v2.xml',
   wp_dir + 'unstable/xdg-decoration/xdg-decoration-unstable-v1.xml',
+  wp_dir + 'unstable/keyboard-shortcuts-inhibit/keyboard-shortcuts-inhibit-unstable-v1.xml',
 ]
 
 foreach xml : protocol_xmls

--- a/waywall/config/api.c
+++ b/waywall/config/api.c
@@ -1261,7 +1261,7 @@ l_set_keyboard_shortcuts_inhibition(lua_State *L) {
     }
 
     luaL_argcheck(L, lua_type(L, ARG_INHIBIT) == LUA_TBOOLEAN, ARG_INHIBIT,
-                  "the value must be a boolean");
+                  "inhibit must be a boolean");
     bool inhibit = lua_toboolean(L, ARG_INHIBIT);
 
     lua_settop(L, ARG_INHIBIT);

--- a/waywall/config/api.c
+++ b/waywall/config/api.c
@@ -1249,6 +1249,47 @@ l_toggle_fullscreen(lua_State *L) {
     return 0;
 }
 
+static int
+l_set_keyboard_shortcuts_inhibition(lua_State *L) {
+    static constexpr int ARG_INHIBIT = 1;
+
+    // Prologue
+    struct config_vm *vm = config_vm_from(L);
+    struct wrap *wrap = config_vm_get_wrap(vm);
+    if (!wrap) {
+        return luaL_error(L, STARTUP_ERRMSG("set_keyboard_shortcuts_inhibition"));
+    }
+
+    luaL_argcheck(L, lua_type(L, ARG_INHIBIT) == LUA_TBOOLEAN, ARG_INHIBIT,
+                  "the value must be a boolean");
+    bool inhibit = lua_toboolean(L, ARG_INHIBIT);
+
+    lua_settop(L, ARG_INHIBIT);
+
+    // Body
+    wrap_lua_set_keyboard_shortcuts_inhibition(wrap, inhibit);
+
+    // Epilogue
+    return 0;
+}
+
+static int
+l_keyboard_shortcuts_inhibited(lua_State *L) {
+    // Prologue
+    struct config_vm *vm = config_vm_from(L);
+    struct wrap *wrap = config_vm_get_wrap(vm);
+    if (!wrap) {
+        return luaL_error(L, STARTUP_ERRMSG("keyboard_shortcuts_inhibited"));
+    }
+
+    // Body
+    bool inhibited = wrap_lua_keyboard_shortcuts_inhibited(wrap);
+
+    // Epilogue
+    lua_pushboolean(L, inhibited);
+    return 1;
+}
+
 static const struct luaL_Reg lua_lib[] = {
     // public (see api.lua)
     {"active_res", l_active_res},
@@ -1269,6 +1310,8 @@ static const struct luaL_Reg lua_lib[] = {
     {"state", l_state},
     {"text", l_text},
     {"toggle_fullscreen", l_toggle_fullscreen},
+    {"set_keyboard_shortcuts_inhibition", l_set_keyboard_shortcuts_inhibition},
+    {"keyboard_shortcuts_inhibited", l_keyboard_shortcuts_inhibited},
 
     // private (see init.lua)
     {"log", l_log},

--- a/waywall/config/config.c
+++ b/waywall/config/config.c
@@ -32,6 +32,7 @@ static const struct config defaults = {
         {
             .fullscreen_width = 0,
             .fullscreen_height = 0,
+            .inhibit_keyboard_shortcuts = false,
         },
     .input =
         {
@@ -597,6 +598,11 @@ process_config_window(struct config *cfg) {
     if (cfg->window.fullscreen_height < 0) {
         ww_log(LOG_ERROR,
                "'window.fullscreen_height' must be a non-negative integer (0 = native resolution)");
+        return 1;
+    }
+
+    if (get_bool(cfg, "inhibit_keyboard_shortcuts", &cfg->window.inhibit_keyboard_shortcuts,
+                 "window.inhibit_keyboard_shortcuts", false) != 0) {
         return 1;
     }
 

--- a/waywall/lua/api.lua
+++ b/waywall/lua/api.lua
@@ -151,4 +151,10 @@ M.text = priv.text
 --- Toggle the Waywall window between fullscreen and not
 M.toggle_fullscreen = priv.toggle_fullscreen
 
+--- Set whether host compositor's shortcuts should be inhibited
+M.set_keyboard_shortcuts_inhibition = priv.set_keyboard_shortcuts_inhibition
+
+--- Gets the current keyboard shortcuts inhibition state
+M.keyboard_shortcuts_inhibited = priv.keyboard_shortcuts_inhibited
+
 package.loaded["waywall"] = M

--- a/waywall/server/backend.c
+++ b/waywall/server/backend.c
@@ -7,6 +7,7 @@
 #include "relative-pointer-unstable-v1-client-protocol.h"
 #include "single-pixel-buffer-v1-client-protocol.h"
 #include "tearing-control-v1-client-protocol.h"
+#include "keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
 #include "util/alloc.h"
 #include "util/log.h"
 #include "viewporter-client-protocol.h"
@@ -45,6 +46,7 @@ static constexpr int USE_TEARING_CONTROL_VERSION = 1;
 static constexpr int USE_VIEWPORTER_VERSION = 1;
 static constexpr int USE_XDG_DECORATION_VERSION = 1;
 static constexpr int USE_XDG_WM_BASE_VERSION = 1;
+static constexpr int USE_KEYBOARD_SHORTCUTS_INHIBIT_VERSION = 1;
 
 struct seat_name {
     struct wl_list link; // server_backend.seat.names
@@ -302,6 +304,16 @@ on_registry_global(void *data, struct wl_registry *wl, uint32_t name, const char
         check_alloc(backend->xdg_wm_base);
 
         xdg_wm_base_add_listener(backend->xdg_wm_base, &xdg_wm_base_listener, backend);
+    } else if (strcmp(iface, zwp_keyboard_shortcuts_inhibit_manager_v1_interface.name) == 0) {
+        if (version < USE_KEYBOARD_SHORTCUTS_INHIBIT_VERSION) {
+            ww_log(LOG_WARN, "host compositor provides outdated zwp_keyboard-shortcuts-inhibit (%d < %d)",
+                   version, USE_KEYBOARD_SHORTCUTS_INHIBIT_VERSION);
+            return;
+        }
+
+        backend->keyboard_shortcuts_inhibit_manager =
+            wl_registry_bind(wl, name, &zwp_keyboard_shortcuts_inhibit_manager_v1_interface,
+                             USE_KEYBOARD_SHORTCUTS_INHIBIT_VERSION);
     }
 }
 
@@ -386,6 +398,9 @@ server_backend_create() {
     if (!backend->xdg_decoration_manager) {
         ww_log(LOG_WARN, "host compositor does not provide zxdg_decoration_manager");
     }
+    if (!backend->keyboard_shortcuts_inhibit_manager) {
+        ww_log(LOG_INFO, "host compositor does not provide zwp_keyboard_shortcuts_inhibit_manager");
+    }
 
     return backend;
 
@@ -449,6 +464,9 @@ server_backend_destroy(struct server_backend *backend) {
     }
     if (backend->xdg_decoration_manager) {
         zxdg_decoration_manager_v1_destroy(backend->xdg_decoration_manager);
+    }
+    if (backend->keyboard_shortcuts_inhibit_manager) {
+        zwp_keyboard_shortcuts_inhibit_manager_v1_destroy(backend->keyboard_shortcuts_inhibit_manager);
     }
 
     wl_registry_destroy(backend->registry);

--- a/waywall/server/ui.c
+++ b/waywall/server/ui.c
@@ -7,6 +7,7 @@
 #include "server/surface.h"
 #include "single-pixel-buffer-v1-client-protocol.h"
 #include "tearing-control-v1-client-protocol.h"
+#include "keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
 #include "util/alloc.h"
 #include "util/debug.h"
 #include "util/log.h"
@@ -431,6 +432,9 @@ server_ui_destroy(struct server_ui *ui) {
     if (ui->root.tearing_control) {
         wp_tearing_control_v1_destroy(ui->root.tearing_control);
     }
+    if (ui->root.keyboard_shortcut_inhibitor) {
+        zwp_keyboard_shortcuts_inhibitor_v1_destroy(ui->root.keyboard_shortcut_inhibitor);
+    }
     if (ui->xdg_decoration) {
         zxdg_toplevel_decoration_v1_destroy(ui->xdg_decoration);
     }
@@ -475,6 +479,28 @@ server_ui_set_fullscreen(struct server_ui *ui, bool fullscreen) {
 }
 
 void
+server_ui_set_keyboard_shortcuts_inhibition(struct server_ui *ui, bool inhibit) {
+    if (!ui->server->backend->keyboard_shortcuts_inhibit_manager) {
+        return;
+    }
+
+    if (inhibit && !ui->root.keyboard_shortcut_inhibitor) {
+        ui->root.keyboard_shortcut_inhibitor = zwp_keyboard_shortcuts_inhibit_manager_v1_inhibit_shortcuts(
+            ui->server->backend->keyboard_shortcuts_inhibit_manager,
+            ui->root.surface,
+            ui->server->backend->seat.remote);
+    } else if (!inhibit && ui->root.keyboard_shortcut_inhibitor) {
+        zwp_keyboard_shortcuts_inhibitor_v1_destroy(ui->root.keyboard_shortcut_inhibitor);
+        ui->root.keyboard_shortcut_inhibitor = nullptr;
+    }
+}
+
+bool
+server_ui_keyboard_shortcuts_inhibited(struct server_ui *ui) {
+    return ui->root.keyboard_shortcut_inhibitor;
+}
+
+void
 server_ui_show(struct server_ui *ui) {
     ww_assert(!ui->mapped);
 
@@ -508,6 +534,7 @@ server_ui_use_config(struct server_ui *ui, struct server_ui_config *config) {
                                           ? WP_TEARING_CONTROL_V1_PRESENTATION_HINT_ASYNC
                                           : WP_TEARING_CONTROL_V1_PRESENTATION_HINT_VSYNC);
     }
+    server_ui_set_keyboard_shortcuts_inhibition(ui, config->inhibit_keyboard_shortcuts);
     if (ui->mapped) {
         wl_surface_attach(ui->root.surface, config->background, 0, 0);
         wl_surface_damage_buffer(ui->root.surface, 0, 0, INT32_MAX, INT32_MAX);
@@ -540,6 +567,7 @@ server_ui_config_create(struct server_ui *ui, struct config *cfg) {
     config->tearing = cfg->experimental.tearing;
     config->fullscreen_width = cfg->window.fullscreen_width;
     config->fullscreen_height = cfg->window.fullscreen_height;
+    config->inhibit_keyboard_shortcuts = cfg->window.inhibit_keyboard_shortcuts;
 
     config->ninb_opacity = cfg->theme.ninb.opacity * UINT32_MAX;
 

--- a/waywall/wrap.c
+++ b/waywall/wrap.c
@@ -731,3 +731,13 @@ void
 wrap_lua_toggle_fullscreen(struct wrap *wrap) {
     server_ui_set_fullscreen(wrap->server->ui, !wrap->server->ui->fullscreen);
 }
+
+void
+wrap_lua_set_keyboard_shortcuts_inhibition(struct wrap *wrap, bool inhibit) {
+    server_ui_set_keyboard_shortcuts_inhibition(wrap->server->ui, inhibit);
+}
+
+bool
+wrap_lua_keyboard_shortcuts_inhibited(struct wrap *wrap) {
+    return server_ui_keyboard_shortcuts_inhibited(wrap->server->ui);
+}


### PR DESCRIPTION
[zwp_keyboard_shortcuts_inhibit_manager](https://wayland.app/protocols/keyboard-shortcuts-inhibit-unstable-v1) support

Active/inactive events are ignored, I think this is correct, `waywall.keyboard_shortcuts_inhibited` is probably only useful for toggling it, so whether the inhibition is actually active is irrelevant.