### PR TITLE
lua pointer confinement api

### DIFF
--- a/doc/02_waywall_set_pointer_confinement.md
+++ b/doc/02_waywall_set_pointer_confinement.md
@@ -1,0 +1,12 @@
+# set_pointer_confinement
+
+This function enables or disables pointer confinement. It behaves the same
+as the `confine_pointer` option in the [input configuration table].
+
+### Arguments
+
+  - `confine`: boolean
+
+> This function cannot be called during startup.
+
+[input configuration table]: 01_options_input.md

--- a/waywall/config/api.c
+++ b/waywall/config/api.c
@@ -11,6 +11,7 @@
 #include "server/ui.h"
 #include "server/wl_seat.h"
 #include "server/wp_relative_pointer.h"
+#include "server/wp_pointer_constraints.h"
 #include "timer.h"
 #include "util/alloc.h"
 #include "util/box.h"
@@ -1249,6 +1250,30 @@ l_toggle_fullscreen(lua_State *L) {
     return 0;
 }
 
+static int
+l_set_pointer_confinement(lua_State *L) {
+    static constexpr int ARG_CONFINE = 1;
+
+    // Prologue
+    struct config_vm *vm = config_vm_from(L);
+    struct wrap *wrap = config_vm_get_wrap(vm);
+    if (!wrap) {
+        return luaL_error(L, STARTUP_ERRMSG("set_pointer_confinement"));
+    }
+
+    luaL_argcheck(L, lua_type(L, ARG_CONFINE) == LUA_TBOOLEAN, ARG_CONFINE,
+                  "confine must be a boolean");
+    bool confine = lua_toboolean(L, ARG_CONFINE);
+
+    lua_settop(L, ARG_CONFINE);
+
+    // Body
+    server_pointer_constraints_set_confine(wrap->server->pointer_constraints, confine);
+
+    // Epilogue
+    return 0;
+}
+
 static const struct luaL_Reg lua_lib[] = {
     // public (see api.lua)
     {"active_res", l_active_res},
@@ -1269,6 +1294,7 @@ static const struct luaL_Reg lua_lib[] = {
     {"state", l_state},
     {"text", l_text},
     {"toggle_fullscreen", l_toggle_fullscreen},
+    {"set_pointer_confinement", l_set_pointer_confinement},
 
     // private (see init.lua)
     {"log", l_log},

--- a/waywall/lua/api.lua
+++ b/waywall/lua/api.lua
@@ -151,4 +151,7 @@ M.text = priv.text
 --- Toggle the Waywall window between fullscreen and not
 M.toggle_fullscreen = priv.toggle_fullscreen
 
+--- Set whether the pointer should be confined to the waywall window
+M.set_pointer_confinement = priv.set_pointer_confinement
+
 package.loaded["waywall"] = M

--- a/waywall/server/wp_pointer_constraints.c
+++ b/waywall/server/wp_pointer_constraints.c
@@ -92,6 +92,10 @@ unlock_pointer(struct server_pointer_constraints *pointer_constraints, struct wl
         check_alloc(pointer_constraints->confined_pointer);
         wl_surface_commit(pointer_constraints->server->ui->root.surface);
     }
+    if (!pointer_constraints->config.confine && pointer_constraints->confined_pointer) {
+        zwp_confined_pointer_v1_destroy(pointer_constraints->confined_pointer);
+        pointer_constraints->confined_pointer = nullptr;
+    }
 
     if (pointer_constraints->locked) {
         wl_signal_emit_mutable(&pointer_constraints->server->events.pointer_unlock, nullptr);


### PR DESCRIPTION
Useful for turning off pointer confinement with a hotkey / state-output.

Also fixes a bug where pointer confinement wouldn't be released after a config hot reload until the pointer was locked and unlocked.