### PR TITLE
fix MCSR Launcher instance recognition

### DIFF
--- a/waywall/instance.c
+++ b/waywall/instance.c
@@ -45,7 +45,6 @@ check_subdirs(const char *dirname) {
         "logs",
         "resourcepacks",
         "saves",
-        "screenshots",
     };
 
     DIR *dir = opendir(dirname);


### PR DESCRIPTION
MCSR Launcher doesn't create the screenshots directory by default. logs, resourcepacks & saves should be enough anyway.

[repro on linuxcord](https://canary.discord.com/channels/1095808506239651942/1424239180313264250/1545908971456569386)